### PR TITLE
Added `sqlglot` to the mix

### DIFF
--- a/linters/sql/Dockerfile
+++ b/linters/sql/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:slim
 
 RUN pip install --upgrade pip \
- && pip install --no-cache-dir pglast sqlfluff sqlparse
+ && pip install --no-cache-dir pglast sqlfluff sqlglot sqlparse
 
 WORKDIR /usr/src
 

--- a/linters/sql/README.md
+++ b/linters/sql/README.md
@@ -4,6 +4,7 @@ favourite):
 
 * [`pglast`](https://github.com/lelit/pglast)
 * [`sqlfluff`](https://github.com/sqlfluff/sqlfluff)
+* [`sqlglot`](https://github.com/tobymao/sqlglot)
 * [`sqlparse`](https://github.com/andialbrecht/sqlparse)
 
 Users and groups are mounted (read-only) from the host system to avoid ownership issues.


### PR DESCRIPTION
[`sqlglot`](https://github.com/tobymao/sqlglot) seems like a good candidate